### PR TITLE
Added warning message for if no boats are shown on boat type sceen

### DIFF
--- a/ProjectBotenReservering.App/ViewModels/BoatTypesViewModel.cs
+++ b/ProjectBotenReservering.App/ViewModels/BoatTypesViewModel.cs
@@ -36,7 +36,21 @@ public partial class BoatTypesViewModel : BaseViewModel
         SelectedSteeringOption = SteeringOptions.First();
         ApplyFilterOption();
     }
+    
+    public async Task OnApearing()
+    {
+        await ValidateBoatTypeList();
+    }
 
+    private async Task ValidateBoatTypeList()
+    {
+        if (AllBoatTypes.Count == 0)
+            await Shell.Current.DisplayAlert(
+                "Alert",
+                "Geen boten binnen client rang gevonden. Neem contact op met de beheerder.",
+                "OK");
+    }
+    
     private void ApplyFilterOption()
     {
         bool? steeringValue = SelectedSteeringOption?.Value;

--- a/ProjectBotenReservering.App/Views/BoatTypesView.xaml.cs
+++ b/ProjectBotenReservering.App/Views/BoatTypesView.xaml.cs
@@ -14,5 +14,15 @@ public partial class BoatTypesView : ContentPage
         InitializeComponent();
 
         BindingContext = viewModel;
+        
+        Loaded += BoatTypesView_Loaded;
+    }
+    
+    private async void BoatTypesView_Loaded(object? sender, EventArgs e)
+    {
+        if (BindingContext is BoatTypesViewModel vm)
+        {
+            await vm.OnApearing();
+        }
     }
 }


### PR DESCRIPTION
This PR introduces the warning required for UserStory 20 (US20). 
It includes the showing of a warning message if the boat type screen is empty by adding a check on the "Loaded" event of the view. 