### PR TITLE
fix(ui): stabilize reservation form layout and enable list scrolling

### DIFF
--- a/ProjectBotenReservering.App/Views/ReservationFormView.xaml
+++ b/ProjectBotenReservering.App/Views/ReservationFormView.xaml
@@ -1,347 +1,340 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cal="clr-namespace:Plugin.Maui.Calendar.Controls;assembly=Plugin.Maui.Calendar"
-             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-             xmlns:vm="clr-namespace:ProjectBotenReservering.App.ViewModels"
-             xmlns:models="clr-namespace:ProjectBotenReservering.Core.Models;assembly=ProjectBotenReservering.Core"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
-             x:Class="ProjectBotenReservering.App.Views.ReservationFormView"
-             x:DataType="vm:ReservationFormViewModel"
-             Shell.NavBarIsVisible="False">
+xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+xmlns:cal="clr-namespace:Plugin.Maui.Calendar.Controls;assembly=Plugin.Maui.Calendar"
+xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+xmlns:vm="clr-namespace:ProjectBotenReservering.App.ViewModels"
+xmlns:models="clr-namespace:ProjectBotenReservering.Core.Models;assembly=ProjectBotenReservering.Core"
+xmlns:sys="clr-namespace:System;assembly=mscorlib"
+x:Class="ProjectBotenReservering.App.Views.ReservationFormView"
+x:DataType="vm:ReservationFormViewModel"
+Shell.NavBarIsVisible="False">
 
-    <ContentPage.Behaviors>
-        <toolkit:EventToCommandBehavior EventName="Appearing" 
-                                        Command="{Binding LoadReservationsCommand}" />
-    </ContentPage.Behaviors>
+<ContentPage.Behaviors>
+    <toolkit:EventToCommandBehavior EventName="Appearing" 
+                                    Command="{Binding LoadReservationsCommand}" />
+</ContentPage.Behaviors>
 
-    <ContentPage.Resources>
-        <ResourceDictionary>
-            <Style x:Key="CalYearLabelStyle" TargetType="Label">
-                <Setter Property="TextColor" Value="{StaticResource Primary}" />
-                <Setter Property="FontSize" Value="20" />
-                <Setter Property="FontAttributes" Value="Bold" />
-                <Setter Property="HorizontalTextAlignment" Value="Center" />
-            </Style>
-            <Style x:Key="CalMonthLabelStyle" TargetType="Label">
-                <Setter Property="TextColor" Value="{StaticResource Primary}" />
-                <Setter Property="FontSize" Value="20" />
-                <Setter Property="FontAttributes" Value="Bold" />
-                <Setter Property="HorizontalTextAlignment" Value="Center" />
-            </Style>
-            <Style x:Key="CalDayLabelStyle" TargetType="Label">
-                <Setter Property="TextColor" Value="Black" />
-                <Setter Property="FontSize" Value="14" />
-                <Setter Property="HorizontalTextAlignment" Value="Center" />
-                <Setter Property="VerticalTextAlignment" Value="Center" />
-            </Style>
-            <Style x:Key="CalSelectedDateLabelStyle" TargetType="Label">
-                <Setter Property="TextColor" Value="White" />
-                <Setter Property="FontAttributes" Value="Bold" />
-                <Setter Property="HorizontalTextAlignment" Value="Center" />
-                <Setter Property="VerticalTextAlignment" Value="Center" />
-            </Style>
-            <Style x:Key="CalWeekdayTitleStyle" TargetType="Label">
-                <Setter Property="TextColor" Value="{StaticResource Primary}" />
-                <Setter Property="FontSize" Value="12" />
-                <Setter Property="HorizontalTextAlignment" Value="Center" />
-            </Style>
-        </ResourceDictionary>
-    </ContentPage.Resources>
+<ContentPage.Resources>
+    <ResourceDictionary>
+        <Style x:Key="CalYearLabelStyle" TargetType="Label">
+            <Setter Property="TextColor" Value="{StaticResource Primary}" />
+            <Setter Property="FontSize" Value="20" />
+            <Setter Property="FontAttributes" Value="Bold" />
+            <Setter Property="HorizontalTextAlignment" Value="Center" />
+        </Style>
+        <Style x:Key="CalMonthLabelStyle" TargetType="Label">
+            <Setter Property="TextColor" Value="{StaticResource Primary}" />
+            <Setter Property="FontSize" Value="20" />
+            <Setter Property="FontAttributes" Value="Bold" />
+            <Setter Property="HorizontalTextAlignment" Value="Center" />
+        </Style>
+        <Style x:Key="CalDayLabelStyle" TargetType="Label">
+            <Setter Property="TextColor" Value="Black" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="HorizontalTextAlignment" Value="Center" />
+            <Setter Property="VerticalTextAlignment" Value="Center" />
+        </Style>
+        <Style x:Key="CalSelectedDateLabelStyle" TargetType="Label">
+            <Setter Property="TextColor" Value="White" />
+            <Setter Property="FontAttributes" Value="Bold" />
+            <Setter Property="HorizontalTextAlignment" Value="Center" />
+            <Setter Property="VerticalTextAlignment" Value="Center" />
+        </Style>
+        <Style x:Key="CalWeekdayTitleStyle" TargetType="Label">
+            <Setter Property="TextColor" Value="{StaticResource Primary}" />
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="HorizontalTextAlignment" Value="Center" />
+        </Style>
+    </ResourceDictionary>
+</ContentPage.Resources>
 
-    <Grid RowDefinitions="Auto, Auto, Auto, Auto" 
-          Padding="10" 
-          RowSpacing="10">
+<Grid RowDefinitions="Auto, Auto, Auto, Auto" 
+      Padding="10" 
+      RowSpacing="10">
 
-        <!-- Header -->
-        <Grid Grid.Row="0" 
-              ColumnDefinitions="Auto, *" 
-              Margin="0,0,0,10">
-            <Button Grid.Column="0" 
-                    Text="Terug" 
-                    Command="{Binding BackCommand}" 
-                    BackgroundColor="LightGray" 
-                    TextColor="Black" 
-                    HeightRequest="36" 
-                    HorizontalOptions="Start" />
-            <Label Grid.Column="1" 
-                   Text="{Binding CurrentBoatType.Name, TargetNullValue=''}" 
-                   FontSize="18" 
-                   FontAttributes="Bold" 
-                   HorizontalOptions="Center" 
-                   VerticalOptions="Center" />
-        </Grid>
+    <Grid Grid.Row="0" 
+          ColumnDefinitions="Auto, *" 
+          Margin="0,0,0,10">
+        <Button Grid.Column="0" 
+                Text="Terug" 
+                Command="{Binding BackCommand}" 
+                BackgroundColor="LightGray" 
+                TextColor="Black" 
+                HeightRequest="36" 
+                HorizontalOptions="Start" />
+        <Label Grid.Column="1" 
+               Text="{Binding CurrentBoatType.Name, TargetNullValue=''}" 
+               FontSize="18" 
+               FontAttributes="Bold" 
+               HorizontalOptions="Center" 
+               VerticalOptions="Center" />
+    </Grid>
 
-        <!-- Calendar and Current Reservations -->
-        <Grid Grid.Row="1" 
-              ColumnDefinitions="Auto, 300" 
-              ColumnSpacing="10" 
-              HorizontalOptions="Center">
+    <Grid Grid.Row="1" 
+          ColumnDefinitions="Auto, 300" 
+          ColumnSpacing="10" 
+          HorizontalOptions="Center">
 
-            <!-- Calendar Section -->
-            <Border Grid.Column="0" 
-                    Stroke="{StaticResource Primary}" 
-                    StrokeThickness="4" 
-                    StrokeShape="RoundRectangle 20,0,0,20" 
-                    Background="{StaticResource Primary}" 
-                    Padding="1,1">
-                <VerticalStackLayout Spacing="5" 
-                                     BackgroundColor="{StaticResource Secondary}">
-                    <cal:Calendar SelectedDate="{Binding SelectedDate}" 
-                                  MinimumDate="{Binding MinDate, FallbackValue={x:Static sys:DateTime.Now}}" 
-                                  YearLabelStyle="{StaticResource CalYearLabelStyle}" 
-                                  MonthLabelStyle="{StaticResource CalMonthLabelStyle}" 
-                                  DaysLabelStyle="{StaticResource CalDayLabelStyle}" 
-                                  SelectedDateLabelStyle="{StaticResource CalSelectedDateLabelStyle}" 
-                                  DaysTitleLabelStyle="{StaticResource CalWeekdayTitleStyle}" 
-                                  SelectedDayBackgroundColor="{StaticResource Primary}" 
-                                  TodayOutlineColor="{StaticResource Primary}" 
-                                  Events="{Binding Events}" 
-                                  EventsScrollViewVisible="False" 
-                                  EventIndicatorColor="Blue" 
-                                  EventIndicatorSelectedColor="LightBlue" 
-                                  VerticalOptions="Fill" 
-                                  SwipeUpToHideEnabled="False" 
-                                  FooterSectionVisible="False" 
-                                  HeightRequest="420" 
-                                  WidthRequest="700" 
-                                  FirstDayOfWeek="Monday">
-                        <cal:Calendar.EventTemplate>
-                            <DataTemplate x:DataType="models:Reservation">
-                                <StackLayout>
-                                    <Label Text="{Binding ClientId}" />
-                                    <Label Text="{Binding BoatId}" />
-                                </StackLayout>
-                            </DataTemplate>
-                        </cal:Calendar.EventTemplate>
-                    </cal:Calendar>
+        <Border Grid.Column="0" 
+                Stroke="{StaticResource Primary}" 
+                StrokeThickness="4" 
+                StrokeShape="RoundRectangle 20,0,0,20" 
+                Background="{StaticResource Primary}" 
+                Padding="1,1"
+                HeightRequest="460">
+            <VerticalStackLayout Spacing="5" 
+                                 BackgroundColor="{StaticResource Secondary}">
+                <cal:Calendar SelectedDate="{Binding SelectedDate}" 
+                              MinimumDate="{Binding MinDate, FallbackValue={x:Static sys:DateTime.Now}}" 
+                              YearLabelStyle="{StaticResource CalYearLabelStyle}" 
+                              MonthLabelStyle="{StaticResource CalMonthLabelStyle}" 
+                              DaysLabelStyle="{StaticResource CalDayLabelStyle}" 
+                              SelectedDateLabelStyle="{StaticResource CalSelectedDateLabelStyle}" 
+                              DaysTitleLabelStyle="{StaticResource CalWeekdayTitleStyle}" 
+                              SelectedDayBackgroundColor="{StaticResource Primary}" 
+                              TodayOutlineColor="{StaticResource Primary}" 
+                              Events="{Binding Events}" 
+                              EventsScrollViewVisible="False" 
+                              EventIndicatorColor="Blue" 
+                              EventIndicatorSelectedColor="LightBlue" 
+                              VerticalOptions="Fill" 
+                              SwipeUpToHideEnabled="False" 
+                              FooterSectionVisible="False" 
+                              HeightRequest="420" 
+                              WidthRequest="700" 
+                              FirstDayOfWeek="Monday">
+                    <cal:Calendar.EventTemplate>
+                        <DataTemplate x:DataType="models:Reservation">
+                            <StackLayout>
+                                <Label Text="{Binding ClientId}" />
+                                <Label Text="{Binding BoatId}" />
+                            </StackLayout>
+                        </DataTemplate>
+                    </cal:Calendar.EventTemplate>
+                </cal:Calendar>
 
-                    <Label Text="{Binding DateWarningText}" 
-                           IsVisible="{Binding HasDateWarning}" 
-                           TextColor="Red" 
-                           FontSize="12" 
-                           FontAttributes="Bold" 
-                           HorizontalOptions="Center" />
-                </VerticalStackLayout>
-            </Border>
-
-            <!-- Current Reservations List -->
-            <Border Grid.Column="1" 
-                    Stroke="{StaticResource Primary}" 
-                    StrokeThickness="2" 
-                    StrokeShape="RoundRectangle 10" 
-                    BackgroundColor="White" 
-                    Padding="10" 
-                    VerticalOptions="Fill">
-                <Grid RowDefinitions="Auto, *">
-                    <Label Grid.Row="0" 
-                           Text="Huidige reserveringen" 
-                           FontSize="16" 
-                           FontAttributes="Bold" 
-                           TextColor="{StaticResource Primary}" 
-                           Margin="0,0,0,10"/>
-
-                    <CollectionView Grid.Row="1" 
-                                    ItemsSource="{Binding Reservations}" 
-                                    EmptyView="Nog geen reserveringen">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="models:Reservation">
-                                <Border Margin="0,0,0,8" 
-                                        Padding="10" 
-                                        Stroke="LightGray" 
-                                        StrokeShape="5">
-                                    <VerticalStackLayout Spacing="2">
-                                        <HorizontalStackLayout Spacing="5">
-                                            <Label Text="{Binding StartTime, StringFormat='{0:HH:mm}'}" 
-                                                   FontAttributes="Bold" 
-                                                   TextColor="Black"/>
-                                            <Label Text="-" 
-                                                   TextColor="Black"/>
-                                            <Label Text="{Binding EndTime, StringFormat='{0:HH:mm}'}" 
-                                                   FontAttributes="Bold" 
-                                                   TextColor="Black"/>
-                                        </HorizontalStackLayout>
-                                        <Label Text="{Binding ClientId, StringFormat='Client ID: {0}'}" 
-                                               FontSize="12" 
-                                               TextColor="Gray"/>
-                                        <Label Text="{Binding BoatId, StringFormat='Boat ID: {0}'}" 
-                                               FontSize="12" 
-                                               TextColor="Gray"/>
-                                    </VerticalStackLayout>
-                                </Border>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
-                </Grid>
-            </Border>
-        </Grid>
-
-        <!-- Input Section -->
-        <Grid Grid.Row="3" 
-              ColumnDefinitions="*, *" 
-              ColumnSpacing="40" 
-              Margin="20,10,20,0">
-
-            <!-- Time Selection -->
-            <VerticalStackLayout Grid.Column="0" 
-                                 Spacing="30" 
-                                 VerticalOptions="Start" 
-                                 Margin="420,0,0,0">
-                <Label Text="Tijd" 
-                       FontSize="18" 
-                       FontAttributes="Bold" 
-                       TextColor="{StaticResource Primary}" />
-                <VerticalStackLayout>
-                    <Label Text="Starttijd:" 
-                           FontSize="12" 
-                           TextColor="Gray"/>
-                    <TimePicker Format="HH:mm" 
-                                Time="{Binding StartTime}" />
-                </VerticalStackLayout>
-                <VerticalStackLayout>
-                    <Label Text="Eindtijd:" 
-                           FontSize="12" 
-                           TextColor="Gray"/>
-                    <TimePicker Format="HH:mm" 
-                                Time="{Binding EndTime}" />
-                </VerticalStackLayout>
-                <Label Text="{Binding TimeWarningText}" 
-                       IsVisible="{Binding HasTimeWarning}" 
+                <Label Text="{Binding DateWarningText}" 
+                       HeightRequest="20"
                        TextColor="Red" 
                        FontSize="12" 
-                       FontAttributes="Bold" />
+                       FontAttributes="Bold" 
+                       HorizontalOptions="Center" />
             </VerticalStackLayout>
+        </Border>
 
-            <!-- Client Selection -->
-            <Grid Grid.Column="1" 
-                  RowDefinitions="Auto, Auto, Auto, *" 
-                  RowSpacing="10" 
-                  Margin="-150,0,0,0">
+        <Border Grid.Column="1" 
+                Stroke="{StaticResource Primary}" 
+                StrokeThickness="2" 
+                StrokeShape="RoundRectangle 10" 
+                BackgroundColor="White" 
+                Padding="10" 
+                HeightRequest="460"
+                VerticalOptions="Start">
+            <Grid RowDefinitions="Auto, *">
+                <Label Grid.Row="0" 
+                       Text="Huidige reserveringen" 
+                       FontSize="16" 
+                       FontAttributes="Bold" 
+                       TextColor="{StaticResource Primary}" 
+                       Margin="0,0,0,10"/>
 
-                <Grid Grid.Row="0" 
-                      ColumnDefinitions="*, Auto" 
-                      VerticalOptions="Center">
-                    <Label Grid.Column="0" 
-                           Text="Roeiers" 
-                           FontSize="18" 
-                           FontAttributes="Bold" 
-                           TextColor="{StaticResource Primary}" 
-                           VerticalOptions="Center"/>
-                    <Label Grid.Column="1" 
-                           Text="{Binding SeatStatusText}" 
-                           FontSize="18" 
-                           FontAttributes="Bold" 
-                           VerticalOptions="Center" 
-                           TranslationX="-420"/>
-                </Grid>
-
-                <Picker Grid.Row="1" 
-                        Title="Voeg roeier toe"
-                        ItemsSource="{Binding AvailableClients}"
-                        ItemDisplayBinding="{Binding FullName}"
-                        SelectedItem="{Binding SelectedClientToAdd}"
-                        BackgroundColor="#f0f0f0"
-                        WidthRequest="640"
-                        HorizontalOptions="Start"
-                        IsVisible="{Binding IsPickerSupported}" />
-
-                <!-- MacCatalyst Specific List -->
-                <VerticalStackLayout Grid.Row="2" 
-                                     IsVisible="{Binding IsMacCatalyst}" 
-                                     Spacing="6">
-                    <Label Text="Selecteer roeier:" 
-                           FontSize="12" 
-                           TextColor="Gray" />
-                    <CollectionView ItemsSource="{Binding AvailableClients}" 
-                                    SelectionMode="None" 
-                                    HeightRequest="180">
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="models:Client">
-                                <Border Padding="8" 
-                                        Margin="0,4" 
-                                        Stroke="#e0e0e0" 
-                                        StrokeShape="RoundRectangle 6" 
-                                        BackgroundColor="#ffffff">
-                                    <Grid ColumnDefinitions="*, Auto" 
-                                          VerticalOptions="Center">
-                                        <Label Grid.Column="0" 
-                                               Text="{Binding FullName}" 
-                                               VerticalOptions="Center" 
-                                               FontSize="14" />
-                                        <Button Grid.Column="1" 
-                                                Text="Voeg toe" 
-                                                Clicked="OnAddClientClicked" 
-                                                HeightRequest="30" 
-                                                Padding="10,0" />
-                                    </Grid>
-                                </Border>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
-                </VerticalStackLayout>
-
-                <!-- Selected Clients List -->
-                <CollectionView Grid.Row="3" 
-                                ItemsSource="{Binding SelectedClients}" 
-                                SelectionMode="None" 
-                                HorizontalOptions="Start" 
-                                WidthRequest="646" 
-                                VerticalOptions="Start">
-                    <CollectionView.ItemsLayout>
-                        <GridItemsLayout Orientation="Vertical" 
-                                         Span="2" 
-                                         HorizontalItemSpacing="6" 
-                                         VerticalItemSpacing="6" />
-                    </CollectionView.ItemsLayout>
+                <CollectionView Grid.Row="1" 
+                                ItemsSource="{Binding Reservations}" 
+                                EmptyView="Nog geen reserveringen"
+                                VerticalScrollBarVisibility="Default">
                     <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="models:Client">
-                            <Border Padding="8" 
-                                    Margin="6" 
-                                    Stroke="#e0e0e0" 
-                                    StrokeShape="RoundRectangle 6" 
-                                    BackgroundColor="#ffffff">
-                                <Grid ColumnDefinitions="*, Auto, Auto" 
-                                      VerticalOptions="Center">
-                                    <Label Grid.Column="0" 
-                                           Text="{Binding FullName}" 
-                                           VerticalOptions="Center" 
-                                           FontSize="14" 
-                                           LineBreakMode="WordWrap" />
-                                    <Button Grid.Column="1" 
-                                            Text="!" 
-                                            TextColor="Red" 
-                                            FontAttributes="Bold" 
-                                            FontSize="18" 
-                                            VerticalOptions="Center" 
-                                            Margin="8,0,8,0" 
-                                            BackgroundColor="Transparent" 
-                                            Clicked="OnShowWarningClicked" 
-                                            SemanticProperties.Hint="{Binding QualificationHelpText}" 
-                                            IsVisible="{Binding IsUnderqualified}" />
-                                    <Button Grid.Column="2" 
-                                            Text="X" 
-                                            TextColor="Red" 
-                                            BackgroundColor="Transparent" 
-                                            Clicked="OnRemoveClientClicked" 
-                                            HeightRequest="28" 
-                                            WidthRequest="32" 
-                                            Padding="0" 
-                                            HorizontalOptions="End"/>
-                                </Grid>
+                        <DataTemplate x:DataType="models:Reservation">
+                            <Border Margin="0,0,0,8" 
+                                    Padding="10" 
+                                    Stroke="LightGray" 
+                                    StrokeShape="5">
+                                <VerticalStackLayout Spacing="2">
+                                    <HorizontalStackLayout Spacing="5">
+                                        <Label Text="{Binding StartTime, StringFormat='{0:HH:mm}'}" 
+                                               FontAttributes="Bold" 
+                                               TextColor="Black"/>
+                                        <Label Text="-" 
+                                               TextColor="Black"/>
+                                        <Label Text="{Binding EndTime, StringFormat='{0:HH:mm}'}" 
+                                               FontAttributes="Bold" 
+                                               TextColor="Black"/>
+                                    </HorizontalStackLayout>
+                                    <Label Text="{Binding ClientId, StringFormat='Client ID: {0}'}" 
+                                           FontSize="12" 
+                                           TextColor="Gray"/>
+                                    <Label Text="{Binding BoatId, StringFormat='Boat ID: {0}'}" 
+                                           FontSize="12" 
+                                           TextColor="Gray"/>
+                                </VerticalStackLayout>
                             </Border>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                 </CollectionView>
             </Grid>
-        </Grid>
-
-        <!-- Submit Button -->
-        <Button Grid.Row="3" 
-                Text="Reserveren" 
-                Command="{Binding SaveReservationCommand}" 
-                Margin="0,444,0,0" 
-                FontSize="18" 
-                FontAttributes="Bold" 
-                VerticalOptions="End" />
+        </Border>
     </Grid>
+
+    <Grid Grid.Row="3" 
+          ColumnDefinitions="*, *" 
+          ColumnSpacing="40" 
+          Margin="20,10,20,0">
+
+        <VerticalStackLayout Grid.Column="0" 
+                             Spacing="30" 
+                             VerticalOptions="Start" 
+                             Margin="420,0,0,0">
+            <Label Text="Tijd" 
+                   FontSize="18" 
+                   FontAttributes="Bold" 
+                   TextColor="{StaticResource Primary}" />
+            <VerticalStackLayout>
+                <Label Text="Starttijd:" 
+                       FontSize="12" 
+                       TextColor="Gray"/>
+                <TimePicker Format="HH:mm" 
+                            Time="{Binding StartTime}" />
+            </VerticalStackLayout>
+            <VerticalStackLayout>
+                <Label Text="Eindtijd:" 
+                       FontSize="12" 
+                       TextColor="Gray"/>
+                <TimePicker Format="HH:mm" 
+                            Time="{Binding EndTime}" />
+            </VerticalStackLayout>
+            <Label Text="{Binding TimeWarningText}" 
+                   IsVisible="{Binding HasTimeWarning}" 
+                   TextColor="Red" 
+                   FontSize="12" 
+                   FontAttributes="Bold" />
+        </VerticalStackLayout>
+
+        <Grid Grid.Column="1" 
+              RowDefinitions="Auto, Auto, Auto, *" 
+              RowSpacing="10" 
+              Margin="-150,0,0,0">
+
+            <Grid Grid.Row="0" 
+                  ColumnDefinitions="*, Auto" 
+                  VerticalOptions="Center">
+                <Label Grid.Column="0" 
+                       Text="Roeiers" 
+                       FontSize="18" 
+                       FontAttributes="Bold" 
+                       TextColor="{StaticResource Primary}" 
+                       VerticalOptions="Center"/>
+                <Label Grid.Column="1" 
+                       Text="{Binding SeatStatusText}" 
+                       FontSize="18" 
+                       FontAttributes="Bold" 
+                       VerticalOptions="Center" 
+                       TranslationX="-420"/>
+            </Grid>
+
+            <Picker Grid.Row="1" 
+                    Title="Voeg roeier toe"
+                    ItemsSource="{Binding AvailableClients}"
+                    ItemDisplayBinding="{Binding FullName}"
+                    SelectedItem="{Binding SelectedClientToAdd}"
+                    BackgroundColor="#f0f0f0"
+                    WidthRequest="640"
+                    HorizontalOptions="Start"
+                    IsVisible="{Binding IsPickerSupported}" />
+
+            <VerticalStackLayout Grid.Row="2" 
+                                 IsVisible="{Binding IsMacCatalyst}" 
+                                 Spacing="6">
+                <Label Text="Selecteer roeier:" 
+                       FontSize="12" 
+                       TextColor="Gray" />
+                <CollectionView ItemsSource="{Binding AvailableClients}" 
+                                SelectionMode="None" 
+                                HeightRequest="180">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:Client">
+                            <Border Padding="8" 
+                                    Margin="0,4" 
+                                    Stroke="#e0e0e0" 
+                                    StrokeShape="RoundRectangle 6" 
+                                    BackgroundColor="#ffffff">
+                                <Grid ColumnDefinitions="*, Auto" 
+                                      VerticalOptions="Center">
+                                    <Label Grid.Column="0" 
+                                           Text="{Binding FullName}" 
+                                           VerticalOptions="Center" 
+                                           FontSize="14" />
+                                    <Button Grid.Column="1" 
+                                            Text="Voeg toe" 
+                                            Clicked="OnAddClientClicked" 
+                                            HeightRequest="30" 
+                                            Padding="10,0" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </VerticalStackLayout>
+
+            <CollectionView Grid.Row="3" 
+                            ItemsSource="{Binding SelectedClients}" 
+                            SelectionMode="None" 
+                            HorizontalOptions="Start" 
+                            WidthRequest="646" 
+                            VerticalOptions="Start">
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Orientation="Vertical" 
+                                     Span="2" 
+                                     HorizontalItemSpacing="6" 
+                                     VerticalItemSpacing="6" />
+                </CollectionView.ItemsLayout>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="models:Client">
+                        <Border Padding="8" 
+                                Margin="6" 
+                                Stroke="#e0e0e0" 
+                                StrokeShape="RoundRectangle 6" 
+                                BackgroundColor="#ffffff">
+                            <Grid ColumnDefinitions="*, Auto, Auto" 
+                                  VerticalOptions="Center">
+                                <Label Grid.Column="0" 
+                                       Text="{Binding FullName}" 
+                                       VerticalOptions="Center" 
+                                       FontSize="14" 
+                                       LineBreakMode="WordWrap" />
+                                <Button Grid.Column="1" 
+                                        Text="!" 
+                                        TextColor="Red" 
+                                        FontAttributes="Bold" 
+                                        FontSize="18" 
+                                        VerticalOptions="Center" 
+                                        Margin="8,0,8,0" 
+                                        BackgroundColor="Transparent" 
+                                        Clicked="OnShowWarningClicked" 
+                                        SemanticProperties.Hint="{Binding QualificationHelpText}" 
+                                        IsVisible="{Binding IsUnderqualified}" />
+                                <Button Grid.Column="2" 
+                                        Text="X" 
+                                        TextColor="Red" 
+                                        BackgroundColor="Transparent" 
+                                        Clicked="OnRemoveClientClicked" 
+                                        HeightRequest="28" 
+                                        WidthRequest="32" 
+                                        Padding="0" 
+                                        HorizontalOptions="End"/>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </Grid>
+    </Grid>
+
+    <Button Grid.Row="3" 
+            Text="Reserveren" 
+            Command="{Binding SaveReservationCommand}" 
+            Margin="0,390,0,0" 
+            FontSize="18" 
+            FontAttributes="Bold" 
+            VerticalOptions="End" />
+</Grid>
 </ContentPage>


### PR DESCRIPTION
This PR addresses UI stability issues in the Reservation Form view where elements would shift position during validation or when lists grew too long.

**Changes:**
*   **Layout Stability:** Changed the Calendar and "Current Reservations" containers to have a fixed `HeightRequest` of 460. This prevents the Time and Rower inputs from shifting up and down.
*   **Error Message Handling:** Reserved static vertical space (`HeightRequest="20"`) for the calendar validation error label. The UI no longer "jumps" when the error text appears or disappears.
*   **Scrollable List:** Constrained the "Current Reservations" list to the fixed container height and enabled the vertical scrollbar. The list will now scroll internally instead of expanding the page and displacing other elements.
*   **Button Alignment:** Adjusted the top margin of the "Reserveren" button (moved up by 40px) to align correctly with the updated fixed layout.