### PR TITLE
Hotfix: fixed the validate for team selected button logic

### DIFF
--- a/ProjectBotenReservering.App/ViewModels/CompetitionViewModel.cs
+++ b/ProjectBotenReservering.App/ViewModels/CompetitionViewModel.cs
@@ -13,7 +13,21 @@ public partial class CompetitionViewModel(IReservationService reservationService
     private readonly ICompetitionService _competitionService = competitionService;
 
     [ObservableProperty]
-    public partial int TeamCount { get; set; } = 0;
+    public partial string TeamCount { get; set; } = "0";
+
+    partial void OnTeamCountChanged(string value)
+    {
+        if (int.TryParse(value, out int teamCount))
+        {
+            SelectCompetitionBoatTypeIsEnable = teamCount > 1;
+
+            _competitionService.AmountBoats = int.Parse(value);
+        }
+        else
+        {
+            SelectCompetitionBoatTypeIsEnable = false;
+        }
+    }
 
     [ObservableProperty]
     public partial ObservableCollection<Boat> CompetitionBoats { get; set; } = new ObservableCollection<Boat>();
@@ -70,6 +84,12 @@ public partial class CompetitionViewModel(IReservationService reservationService
             // May have to be moved to popup as discussed in wireframe design
             await Shell.Current.GoToAsync(nameof(TweetCreationView), navigationParameter);
         }
+    }
+
+    [RelayCommand]
+    private async Task SelectCompetitionBoatType()
+    {
+        await Shell.Current.GoToAsync(nameof(BoatTypeSelectionCompetitionView));
     }
 
     private async Task<bool> HandleConflictingReservationsAsync(DateTime startDateTime, DateTime endDateTime)


### PR DESCRIPTION
This pull request introduces improvements to the `CompetitionViewModel` class, focusing on how the team count is handled and adding a new command for boat type selection. The most important changes are grouped below:

**Team Count Handling:**

* Changed the `TeamCount` property from `int` to `string` to better handle user input, and added logic to enable or disable boat type selection based on the parsed value. The `OnTeamCountChanged` method ensures that only valid integer inputs greater than 1 enable the selection, and updates the competition service accordingly.

**UI Commands:**

* Added the `SelectCompetitionBoatType` command, which navigates the user to the `BoatTypeSelectionCompetitionView` when triggered. This improves the user flow for selecting boat types in a competition.