### PR TITLE
Unit tests for create competition logic

### DIFF
--- a/TestCore/Services/CompetitionServiceTests.cs
+++ b/TestCore/Services/CompetitionServiceTests.cs
@@ -7,9 +7,11 @@ using ProjectBotenReservering.Core.Services;
 
 namespace TestCore.Services
 {
+    [TestFixture]
     public class CompetitionServiceTests
     {
         private CompetitionService _competitionService;
+
         private Mock<IReservationService> _reservationServiceMock;
         private Mock<IClientService> _clientServiceMock;
         private Mock<IBoatRepository> _boatRepositoryMock;
@@ -33,39 +35,48 @@ namespace TestCore.Services
                 _reservationCompetitionRepositoryMock.Object
             );
         }
+
         [Test]
-        public void CreateMatch_Returns_CompetitionObject()
+        public void CreateCompetition_WithValidData_ReturnsCompetitionAndCreatesReservation()
         {
             // Arrange
-            DateTime startDate = DateTime.Now;
-            DateTime endDate = DateTime.Now.AddHours(2);
+            DateTime startDate = DateTime.Now.AddHours(1);
+            DateTime endDate = startDate.AddHours(2);
             string competitionName = "Test competition";
 
             Client currentClient = new Client("John Doe", "john.doe@example.com", 2, 2, "Test Club", true, "hashedpassword", 1);
-            Boat boat = new Boat("Test boat 1", true, 1, 1, BoatType.S, 1, true, "local", 1);
-            List<Boat> operationalBoats = new List<Boat> { boat };
-            Competition expectedCompetition = new Competition(startDate, endDate, competitionName, 1);
-            Reservation expectedReservation = new Reservation(DateTime.Now, startDate, endDate, currentClient.Id, boat.Id, true, 1);
+
+            Boat boat = new Boat("Test boat", true, 1, 1, BoatType.S, 1, true, "local", 1);
+
+            Competition savedCompetition = new Competition(startDate, endDate, competitionName);
+            
+            savedCompetition.Id = 1;
+
+            Reservation savedReservation = new Reservation(DateTime.Now, startDate, endDate, currentClient.Id, boat.Id, true
+            );
+
+            savedReservation.Id = 1;
 
             _clientServiceMock.Setup(x => x.GetCurrentClient()).Returns(currentClient);
             _boatRepositoryMock.Setup(x => x.Get(boat.Id)).Returns(boat);
-            _boatRepositoryMock.Setup(x => x.GetOperationalBoats()).Returns(operationalBoats);
-            _competitionRepositoryMock.Setup(x => x.Add(It.IsAny<Competition>())).Returns(expectedCompetition);
-            _reservationServiceMock.Setup(x => x.CreateReservation(It.IsAny<Reservation>(), It.IsAny<List<Client>>())).Returns(expectedReservation);
+            _competitionRepositoryMock.Setup(x => x.Add(It.IsAny<Competition>())).Returns(savedCompetition);
+            _reservationServiceMock.Setup(x => x.CreateReservation(It.IsAny<Reservation>(), It.IsAny<List<Client>>())).Returns(savedReservation);
             _reservationCompetitionRepositoryMock.Setup(x => x.Add(It.IsAny<ReservationCompetition>())).Returns((ReservationCompetition rc) => rc);
-
             _competitionService.ClearCompetitionBoats();
             _competitionService.AmountBoats = 1;
             _competitionService.SelectedBoatId = boat.Id;
 
+            // Act
             Competition? result = _competitionService.CreateCompetition(startDate, endDate, competitionName);
 
+            // Assert
             result.Should().NotBeNull();
-            result!.StartDateTime.Should().Be(startDate);
+            result!.CompetitionName.Should().Be(competitionName);
+            result.StartDateTime.Should().Be(startDate);
             result.EndDateTime.Should().Be(endDate);
-            result.CompetitionName.Should().Be(competitionName);
 
             _reservationServiceMock.Verify(x => x.CreateReservation(It.IsAny<Reservation>(), It.IsAny<List<Client>>()), Times.Once);
+            _competitionRepositoryMock.Verify(x => x.Add(It.IsAny<Competition>()), Times.Once);
             _reservationCompetitionRepositoryMock.Verify(x => x.Add(It.IsAny<ReservationCompetition>()), Times.Once);
         }
     }


### PR DESCRIPTION
This pull request adds a new unit test class for the `CompetitionService`, improving test coverage for the competition creation logic. The test uses mocks for all dependencies to isolate the service logic and verifies that a competition is created correctly, including the expected interactions with reservation and repository services.

**New Unit Test for Competition Creation:**

* Added a new `CompetitionServiceTests` class in `TestCore/Services/CompetitionServiceTests.cs` to test the `CreateCompetition` method of `CompetitionService`, including setup of all required service and repository mocks.
* Implemented a test method `CreateMatch_Returns_CompetitionObject` that verifies a competition is created with the correct properties and that the appropriate service and repository methods are called exactly once.