### PR TITLE
feature: add 30min protocol buffer to competition reservations

### DIFF
--- a/ProjectBotenReservering.App/ViewModels/CompetitionViewModel.cs
+++ b/ProjectBotenReservering.App/ViewModels/CompetitionViewModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ProjectBotenReservering.App.Views;
+using ProjectBotenReservering.Core.Helpers;
 using ProjectBotenReservering.Core.Interfaces.Repositories;
 using ProjectBotenReservering.Core.Interfaces.Services;
 using ProjectBotenReservering.Core.Models;
@@ -96,20 +97,14 @@ public partial class CompetitionViewModel : BaseViewModel
     partial void OnEndDateChanged(DateTime value) => _ = ValidateWeatherRulesAsync();
     partial void OnEndTimeChanged(TimeSpan value) => _ = ValidateWeatherRulesAsync();
 
-    private DateTime GetProtocolStartDateTime()
-    {
-        DateTime startDateTime = StartDate.Date + StartTime;
-        return startDateTime.AddMinutes(-30);
-    }
-
     private async Task ValidateWeatherRulesAsync()
     {
         ClearWeatherWarning();
 
         if (CompetitionBoats.Count == 0) return;
 
-        DateTime startDateTime = GetProtocolStartDateTime();
-        DateTime endDateTime = EndDate.Date + EndTime;
+        DateTime startDateTime = CompetitionTimeHelper.GetStartTimeWithPreparation(StartDate, StartTime);
+        DateTime endDateTime = CompetitionTimeHelper.CombineDateAndTime(EndDate, EndTime);
 
         if (endDateTime <= startDateTime) return;
 
@@ -151,17 +146,17 @@ public partial class CompetitionViewModel : BaseViewModel
     [RelayCommand]
     private async Task CreateCompetition()
     {
-        DateTime protocolStartDateTime = GetProtocolStartDateTime();
-        DateTime endDateTime = EndDate.Date + EndTime;
+        DateTime startDateTime = CompetitionTimeHelper.GetStartTimeWithPreparation(StartDate, StartTime);
+        DateTime endDateTime = CompetitionTimeHelper.CombineDateAndTime(EndDate, EndTime);
 
-        if (await CompetitionIsValid(protocolStartDateTime, endDateTime) == false)
+        if (await CompetitionIsValid(startDateTime, endDateTime) == false)
             return;
 
         await ValidateWeatherRulesAsync();
 
-        if (await ShowWarningPopupAsync() && await HandleConflictingReservationsAsync(protocolStartDateTime, endDateTime))
+        if (await ShowWarningPopupAsync() && await HandleConflictingReservationsAsync(startDateTime, endDateTime))
         {
-            await PlaceCompetition(protocolStartDateTime, endDateTime);
+            await PlaceCompetition(startDateTime, endDateTime);
         }
     }
 

--- a/ProjectBotenReservering.Core/Helpers/CompetitionTimeHelper.cs
+++ b/ProjectBotenReservering.Core/Helpers/CompetitionTimeHelper.cs
@@ -1,0 +1,14 @@
+﻿namespace ProjectBotenReservering.Core.Helpers;
+
+public static class CompetitionTimeHelper
+{
+    public static DateTime CombineDateAndTime(DateTime date, TimeSpan time)
+    {
+        return date.Date + time;
+    }
+
+    public static DateTime GetStartTimeWithPreparation(DateTime date, TimeSpan time)
+    {
+        return CombineDateAndTime(date, time).AddMinutes(-30);
+    }
+}


### PR DESCRIPTION
**Link to Story:** https://trello.com/c/SKckKTFP/97-us28-als-wedstrijdcommissaris-wil-ik-een-herinnering-voor-controleprotocollen-ontvangen-zodat-de-veiligheid-en-compliance-gewaar

This pull request implements a mandatory time buffer for competition reservations to ensure compliance with safety protocols. The main focus is on shifting the technical reservation time 30 minutes earlier than the public event time, ensuring boats are blocked and available for the check-out procedure. The changes also include updates to user feedback to ensure transparency about this time adjustment.

**Reservation protocol validation and logic:**

*   Added method to `CompetitionViewModel` to implement a "Protocol Time" logic, which subtracts 30 minutes from the user-selected Start Time.
*   The database creation process (`CreateCompetition`), conflict detection (`HandleConflictingReservationsAsync`), and validation rules now utilize this adjusted time, ensuring the database reflects the check-out period.
*   Ensured that the "Public" time (used for Tweets and display) remains unchanged, so the event is still advertised at the original time (e.g., 17:00), while the database reserves from the protocol time (e.g., 16:30).

**User interface updates:**

*   Updated the confirmation popup in `CreateConfirmationPopupMessage` to include a specific disclaimer regarding the 30-minute protocol shift, giving users explicit notice that the reservation starts earlier than the match time.
